### PR TITLE
Initialisations for rotated BP1 and BP2 configurations, bulk and gradient contributions to the stress

### DIFF
--- a/src/blue_phase.c
+++ b/src/blue_phase.c
@@ -497,10 +497,8 @@ __host__ __device__ int fe_lc_bulk_stress(fe_lc_t * fe, int index,
       for (ic = 0; ic < 3; ic++) {
 	sum += q[ia][ic]*q[ib][ic];
       }
-      h[ia][ib] = -fe->param->a0*(1.0 - r3*gamma)*q[ia][ib]
-	+ fe->param->a0*gamma*(sum - r3*q2*d[ia][ib])
-	- fe->param->a0*gamma*q2*q[ia][ib]
-	- 4.0*kappa1*q0*q0*q[ia][ib];
+      h[ia][ib] = -a0*(1.0 - r3*gamma)*q[ia][ib] + a0*gamma*(sum - r3*q2*d[ia][ib])
+	- a0*gamma*q2*q[ia][ib] - 4.0*kappa1*q0*q0*q[ia][ib];
     }
   }
 

--- a/src/blue_phase.c
+++ b/src/blue_phase.c
@@ -463,8 +463,7 @@ __host__ __device__ int fe_lc_bulk_stress(fe_lc_t * fe, int index,
   double q0;              /* Redshifted value */
   double kappa1;  /* Redshifted value */
 
-  double q2, q3;
-  double dq1;
+  double q2;
   double sum;
   const double r3 = (1.0/3.0);
 
@@ -588,7 +587,7 @@ __host__ __device__ int fe_lc_grad_stress(fe_lc_t * fe, int index,
   double kappa0, kappa1;  /* Redshifted values */
 
   double eq;
-  double dq0, dq1, sum;
+  double sum;
   const double r3 = (1.0/3.0);
 
   int ia, ib, ic, id, ie;

--- a/src/blue_phase.c
+++ b/src/blue_phase.c
@@ -894,17 +894,14 @@ __host__ __device__
 int fe_lc_compute_bulk_h(fe_lc_t * fe, double gamma, double q[3][3],
 		    double h[3][3]) {
 
-  int ia, ib, ic, id;
+  int ia, ib, ic;
 
   double q0;              /* Redshifted value */
   double kappa1;          /* Redshifted value */
   double q2;
-  double e2;
-  double eq;
   double sum;
   const double r3 = (1.0/3.0);
   KRONECKER_DELTA_CHAR(d);
-  LEVI_CIVITA_CHAR(e);
 
   assert(fe);
 
@@ -956,8 +953,6 @@ int fe_lc_compute_grad_h(fe_lc_t * fe, double gamma, double q[3][3],
 
   double q0;              /* Redshifted value */
   double kappa0, kappa1;  /* Redshifted values */
-  double q2;
-  double e2;
   double eq;
   double sum;
   const double r3 = (1.0/3.0);

--- a/src/blue_phase.h
+++ b/src/blue_phase.h
@@ -104,6 +104,12 @@ __host__ __device__
 int fe_lc_mol_field(fe_lc_t * fe, int index, double h[3][3]);
 
 __host__ __device__
+int fe_lc_bulk_mol_field(fe_lc_t * fe, int index, double h[3][3]);
+
+__host__ __device__
+int fe_lc_grad_mol_field(fe_lc_t * fe, int index, double h[3][3]);
+
+__host__ __device__
 int fe_lc_stress(fe_lc_t * fe, int index, double s[3][3]);
 
 __host__ __device__
@@ -118,6 +124,14 @@ int fe_lc_compute_fed(fe_lc_t * fe, double gamma,  double q[3][3],
 
 __host__ __device__
 int fe_lc_compute_h(fe_lc_t * fe, double gaama,	double q[3][3],
+		    double dq[3][3][3],	double dsq[3][3], double h[3][3]);
+
+__host__ __device__
+int fe_lc_compute_bulk_h(fe_lc_t * fe, double gaama,	double q[3][3],
+		    double h[3][3]);
+
+__host__ __device__
+int fe_lc_compute_grad_h(fe_lc_t * fe, double gaama,	double q[3][3],
 		    double dq[3][3][3],	double dsq[3][3], double h[3][3]);
 
 __host__ __device__

--- a/src/blue_phase.h
+++ b/src/blue_phase.h
@@ -119,11 +119,18 @@ __host__ __device__
 int fe_lc_str_anti(fe_lc_t * fe, int index, double s[3][3]);
 
 __host__ __device__
-int fe_lc_compute_fed(fe_lc_t * fe, double gamma,  double q[3][3],
+int fe_lc_compute_fed(fe_lc_t * fe, double gamma, double q[3][3],
 		      double dq[3][3][3], double * fed);
 
 __host__ __device__
-int fe_lc_compute_h(fe_lc_t * fe, double gaama,	double q[3][3],
+int fe_lc_compute_bulk_fed(fe_lc_t * fe, double q[3][3], double * fed);
+
+__host__ __device__
+int fe_lc_compute_gradient_fed(fe_lc_t * fe, double q[3][3],
+		      double dq[3][3][3], double * fed);
+
+__host__ __device__
+int fe_lc_compute_h(fe_lc_t * fe, double gamma, double q[3][3],
 		    double dq[3][3][3],	double dsq[3][3], double h[3][3]);
 
 __host__ __device__

--- a/src/blue_phase.h
+++ b/src/blue_phase.h
@@ -104,13 +104,13 @@ __host__ __device__
 int fe_lc_mol_field(fe_lc_t * fe, int index, double h[3][3]);
 
 __host__ __device__
-int fe_lc_bulk_mol_field(fe_lc_t * fe, int index, double h[3][3]);
-
-__host__ __device__
-int fe_lc_grad_mol_field(fe_lc_t * fe, int index, double h[3][3]);
-
-__host__ __device__
 int fe_lc_stress(fe_lc_t * fe, int index, double s[3][3]);
+
+__host__ __device__
+int fe_lc_bulk_stress(fe_lc_t * fe, int index, double s[3][3]);
+
+__host__ __device__
+int fe_lc_grad_stress(fe_lc_t * fe, int index, double s[3][3]);
 
 __host__ __device__
 int fe_lc_str_symm(fe_lc_t * fe, int index, double s[3][3]);
@@ -127,16 +127,9 @@ int fe_lc_compute_h(fe_lc_t * fe, double gaama,	double q[3][3],
 		    double dq[3][3][3],	double dsq[3][3], double h[3][3]);
 
 __host__ __device__
-int fe_lc_compute_bulk_h(fe_lc_t * fe, double gaama,	double q[3][3],
-		    double h[3][3]);
-
-__host__ __device__
-int fe_lc_compute_grad_h(fe_lc_t * fe, double gaama,	double q[3][3],
-		    double dq[3][3][3],	double dsq[3][3], double h[3][3]);
-
-__host__ __device__
 int fe_lc_compute_stress(fe_lc_t * fe, double q[3][3], double dq[3][3][3],
 			 double h[3][3], double sth[3][3]);
+
 __host__ __device__
 int fe_lc_compute_stress_active(fe_lc_t * fe, double q[3][3], double dp[3][3],
 				double sa[3][3]);

--- a/src/blue_phase_init.c
+++ b/src/blue_phase_init.c
@@ -110,6 +110,11 @@ int blue_phase_O8M_init(cs_t * cs, fe_lc_param_t * param, field_t * fq) {
  *
  *  Initialisation of a rotated BP I
  *
+ *  The sequence of rotations follows the standard Euler angles:
+ *  1) rotation around z-axis obtaining frame x'-y'-z
+ *  2) rotation around x'-axis obtaining frame x'-y''-z'
+ *  3) rotation around z'-axis obtaining final reference
+ *
  *****************************************************************************/
 
 int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const double euler_angles[3]) {
@@ -259,6 +264,11 @@ int blue_phase_O2_init(cs_t * cs, fe_lc_param_t * param, field_t * fq) {
  *  blue_phase_O2_rot_init
  *
  *  This initialisation is for a rotated BP II.
+ *
+ *  The sequence of rotations follows the standard Euler angles:
+ *  1) rotation around z-axis obtaining frame x'-y'-z
+ *  2) rotation around x'-axis obtaining frame x'-y''-z'
+ *  3) rotation around z'-axis obtaining final reference
  *
  *****************************************************************************/
 

--- a/src/blue_phase_init.c
+++ b/src/blue_phase_init.c
@@ -152,9 +152,9 @@ int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, cons
       for (kc = 1; kc <= nlocal[Z]; kc++) {
 	z = noffset[Z] + kc;
 
-	r[X] = x - ntotal[X]/2;
-	r[Y] = y - ntotal[Y]/2;
-	r[Z] = z - ntotal[Z]/2;
+	r[X] = x - ntotal[X]/2.0;
+	r[Y] = y - ntotal[Y]/2.0;
+	r[Z] = z - ntotal[Z]/2.0;
 
 	for(ik=0; ik<3; ik++){
 	  r_rot[ik] = 0.0;
@@ -167,9 +167,9 @@ int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, cons
 	  }
 	}
 
-	r_rot[X] += ntotal[X]/2;
-	r_rot[Y] += ntotal[Y]/2;
-	r_rot[Z] += ntotal[Z]/2;
+	r_rot[X] += ntotal[X]/2.0;
+	r_rot[Y] += ntotal[Y]/2.0;
+	r_rot[Z] += ntotal[Z]/2.0;
 
 	cosx = cos(r2*q0*r_rot[X]);
 	cosy = cos(r2*q0*r_rot[Y]);
@@ -300,9 +300,9 @@ int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const
       for (kc = 1; kc <= nlocal[Z]; kc++) {
 	z = noffset[Z] + kc;
 
-	r[X] = x - ntotal[X]/2;
-	r[Y] = y - ntotal[Y]/2;
-	r[Z] = z - ntotal[Z]/2;
+	r[X] = x - ntotal[X]/2.0;
+	r[Y] = y - ntotal[Y]/2.0;
+	r[Z] = z - ntotal[Z]/2.0;
 
 	for(ik=0; ik<3; ik++){
 	  r_rot[ik] = 0.0;
@@ -315,9 +315,9 @@ int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const
 	  }
 	}
 
-	r_rot[X] += ntotal[X]/2;
-	r_rot[Y] += ntotal[Y]/2;
-	r_rot[Z] += ntotal[Z]/2;
+	r_rot[X] += ntotal[X]/2.0;
+	r_rot[Y] += ntotal[Y]/2.0;
+	r_rot[Z] += ntotal[Z]/2.0;
 
 	cosx = cos(2.0*q0*r_rot[X]);
 	cosy = cos(2.0*q0*r_rot[Y]);

--- a/src/blue_phase_init.c
+++ b/src/blue_phase_init.c
@@ -113,7 +113,7 @@ int blue_phase_O8M_init(cs_t * cs, fe_lc_param_t * param, field_t * fq) {
  *  The sequence of rotations follows the standard Euler angles:
  *  1) rotation around z-axis obtaining frame x'-y'-z
  *  2) rotation around x'-axis obtaining frame x'-y''-z'
- *  3) rotation around z'-axis obtaining final reference
+ *  3) rotation around z'-axis obtaining final frame
  *
  *****************************************************************************/
 
@@ -146,6 +146,8 @@ int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, cons
   q0 = param->q0;
   amplitude0 = param->amplitude0;
 
+  /* Set up rotation matrices with negative angles. Clockwise rotation */
+  /* of arguments leads to counterclockwise rotation of the Q-tensor.  */
   blue_phase_M_rot(MZ, 2,-1.0*pi*euler_angles[0]/180.0);
   blue_phase_M_rot(MXp,0,-1.0*pi*euler_angles[1]/180.0);
   blue_phase_M_rot(MZp,2,-1.0*pi*euler_angles[2]/180.0);
@@ -268,7 +270,7 @@ int blue_phase_O2_init(cs_t * cs, fe_lc_param_t * param, field_t * fq) {
  *  The sequence of rotations follows the standard Euler angles:
  *  1) rotation around z-axis obtaining frame x'-y'-z
  *  2) rotation around x'-axis obtaining frame x'-y''-z'
- *  3) rotation around z'-axis obtaining final reference
+ *  3) rotation around z'-axis obtaining final frame
  *
  *****************************************************************************/
 
@@ -299,6 +301,8 @@ int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const
   q0 = param->q0;
   amplitude0 = param->amplitude0;
 
+  /* Set up rotation matrices with negative angles. Clockwise rotation */
+  /* of arguments leads to counterclockwise rotation of the Q-tensor.  */
   blue_phase_M_rot(MZ, 2,-1.0*pi*euler_angles[0]/180.0);
   blue_phase_M_rot(MXp,0,-1.0*pi*euler_angles[1]/180.0);
   blue_phase_M_rot(MZp,2,-1.0*pi*euler_angles[2]/180.0);

--- a/src/blue_phase_init.c
+++ b/src/blue_phase_init.c
@@ -115,8 +115,7 @@ int blue_phase_O8M_init(cs_t * cs, fe_lc_param_t * param, field_t * fq) {
 int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const double euler_angles[3]) {
 
   int ic, jc, kc;
-  int nlocal[3];
-  int noffset[3];
+  int ntotal[3], nlocal[3], noffset[3];
   int index;
 
   double q[3][3];
@@ -134,6 +133,7 @@ int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, cons
   assert(cs);
   assert(fq);
 
+  cs_ntotal(cs, ntotal);
   cs_nlocal(cs, nlocal);
   cs_nlocal_offset(cs, noffset);
 
@@ -141,9 +141,9 @@ int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, cons
   q0 = param->q0;
   amplitude0 = param->amplitude0;
 
-  blue_phase_M_rot(MZ, 2,pi*euler_angles[0]/180.0);
-  blue_phase_M_rot(MXp,0,pi*euler_angles[1]/180.0);
-  blue_phase_M_rot(MZp,2,pi*euler_angles[2]/180.0);
+  blue_phase_M_rot(MZ, 2,-1.0*pi*euler_angles[0]/180.0);
+  blue_phase_M_rot(MXp,0,-1.0*pi*euler_angles[1]/180.0);
+  blue_phase_M_rot(MZp,2,-1.0*pi*euler_angles[2]/180.0);
 
   for (ic = 1; ic <= nlocal[X]; ic++) {
     x = noffset[X] + ic;
@@ -152,9 +152,9 @@ int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, cons
       for (kc = 1; kc <= nlocal[Z]; kc++) {
 	z = noffset[Z] + kc;
 
-	r[X] = x;
-	r[Y] = y;
-	r[Z] = z;
+	r[X] = x - ntotal[X]/2;
+	r[Y] = y - ntotal[Y]/2;
+	r[Z] = z - ntotal[Z]/2;
 
 	for(ik=0; ik<3; ik++){
 	  r_rot[ik] = 0.0;
@@ -166,6 +166,10 @@ int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, cons
 	    }
 	  }
 	}
+
+	r_rot[X] += ntotal[X]/2;
+	r_rot[Y] += ntotal[Y]/2;
+	r_rot[Z] += ntotal[Z]/2;
 
 	cosx = cos(r2*q0*r_rot[X]);
 	cosy = cos(r2*q0*r_rot[Y]);
@@ -261,8 +265,7 @@ int blue_phase_O2_init(cs_t * cs, fe_lc_param_t * param, field_t * fq) {
 int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const double euler_angles[3]) {
 
   int ic, jc, kc;
-  int nlocal[3];
-  int noffset[3];
+  int ntotal[3], nlocal[3], noffset[3];
   int index;
 
   double q[3][3];
@@ -279,15 +282,16 @@ int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const
   assert(cs);
   assert(fq);
 
+  cs_ntotal(cs, ntotal);
   cs_nlocal(cs, nlocal);
   cs_nlocal_offset(cs, noffset);
 
   q0 = param->q0;
   amplitude0 = param->amplitude0;
 
-  blue_phase_M_rot(MZ, 2,pi*euler_angles[0]/180.0);
-  blue_phase_M_rot(MXp,0,pi*euler_angles[1]/180.0);
-  blue_phase_M_rot(MZp,2,pi*euler_angles[2]/180.0);
+  blue_phase_M_rot(MZ, 2,-1.0*pi*euler_angles[0]/180.0);
+  blue_phase_M_rot(MXp,0,-1.0*pi*euler_angles[1]/180.0);
+  blue_phase_M_rot(MZp,2,-1.0*pi*euler_angles[2]/180.0);
 
   for (ic = 1; ic <= nlocal[X]; ic++) {
     x = noffset[X] + ic;
@@ -296,9 +300,9 @@ int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const
       for (kc = 1; kc <= nlocal[Z]; kc++) {
 	z = noffset[Z] + kc;
 
-	r[X] = x;
-	r[Y] = y;
-	r[Z] = z;
+	r[X] = x - ntotal[X]/2;
+	r[Y] = y - ntotal[Y]/2;
+	r[Z] = z - ntotal[Z]/2;
 
 	for(ik=0; ik<3; ik++){
 	  r_rot[ik] = 0.0;
@@ -310,6 +314,10 @@ int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, const
 	    }
 	  }
 	}
+
+	r_rot[X] += ntotal[X]/2;
+	r_rot[Y] += ntotal[Y]/2;
+	r_rot[Z] += ntotal[Z]/2;
 
 	cosx = cos(2.0*q0*r_rot[X]);
 	cosy = cos(2.0*q0*r_rot[Y]);

--- a/src/blue_phase_init.h
+++ b/src/blue_phase_init.h
@@ -22,7 +22,11 @@
 
 int blue_phase_twist_init(cs_t * cs, fe_lc_param_t * param, field_t * fq, int helical_axis);
 int blue_phase_O8M_init(cs_t * cs, fe_lc_param_t * param, field_t * fq);
+int blue_phase_O8M_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq,
+			const double euler_angles[3]);
 int blue_phase_O2_init(cs_t * cs, fe_lc_param_t * param, field_t * fq);
+int blue_phase_O2_rot_init(cs_t * cs, fe_lc_param_t * param, field_t * fq,
+			const double euler_angles[3]);
 int blue_phase_O5_init(cs_t * cs, fe_lc_param_t * param, field_t * fq);
 int blue_phase_H2D_init(cs_t * cs, fe_lc_param_t * param, field_t * fq);
 int blue_phase_H3DA_init(cs_t * cs, fe_lc_param_t * param, field_t * fq);

--- a/src/blue_phase_rt.c
+++ b/src/blue_phase_rt.c
@@ -344,6 +344,8 @@ __host__ int blue_phase_rt_initial_conditions(pe_t * pe, rt_t * rt, cs_t * cs,
   double nhat[3] = {1.0, 0.0, 0.0};
   double nhat2[3] = {64.0, 3.0, 1.0};
 
+  double euler_angles[3] = {0.0, 0.0, 0.0};
+
   fe_lc_param_t param;
   fe_lc_param_t * feparam = &param;
 
@@ -415,9 +417,27 @@ __host__ int blue_phase_rt_initial_conditions(pe_t * pe, rt_t * rt, cs_t * cs,
     blue_phase_O8M_init(cs, feparam, q);
   }
 
+  if (strcmp(key1, "o8m_rot") == 0) {
+    pe_info(pe, "Initialising Q_ab using rotated O8M (BPI)\n");
+    if (strcmp(key1, "lc_q_euler_angles") == 0) {
+      rt_double_parameter_vector(rt, "lc_q_euler_angles", euler_angles);
+      pe_info(pe, "Euler angles alpha_z=%g, beta_x'=%g, gamma_z'=%g\n", euler_angles[0], euler_angles[1], euler_angles[2]);
+    }
+    blue_phase_O8M_rot_init(cs, feparam, q, euler_angles);
+  }
+
   if (strcmp(key1, "o2") == 0) {
     pe_info(pe, "Initialising Q_ab using O2 (BPII)\n");
     blue_phase_O2_init(cs, feparam, q);
+  }
+
+  if (strcmp(key1, "o2_rot") == 0) {
+    pe_info(pe, "Initialising Q_ab using rotated O2 (BPII)\n");
+    if (strcmp(key1, "lc_q_euler_angles") == 0) {
+      rt_double_parameter_vector(rt, "lc_q_euler_angles", euler_angles);
+      pe_info(pe, "Euler angles alpha_z=%g, beta_x'=%g, gamma_z'=%g\n", euler_angles[0], euler_angles[1], euler_angles[2]);
+    }
+    blue_phase_O2_rot_init(cs, feparam, q, euler_angles);
   }
 
   if (strcmp(key1, "o5") == 0) {

--- a/src/blue_phase_rt.c
+++ b/src/blue_phase_rt.c
@@ -419,10 +419,8 @@ __host__ int blue_phase_rt_initial_conditions(pe_t * pe, rt_t * rt, cs_t * cs,
 
   if (strcmp(key1, "o8m_rot") == 0) {
     pe_info(pe, "Initialising Q_ab using rotated O8M (BPI)\n");
-    if (strcmp(key1, "lc_q_euler_angles") == 0) {
-      rt_double_parameter_vector(rt, "lc_q_euler_angles", euler_angles);
-      pe_info(pe, "Euler angles alpha_z=%g, beta_x'=%g, gamma_z'=%g\n", euler_angles[0], euler_angles[1], euler_angles[2]);
-    }
+    rt_double_parameter_vector(rt, "lc_q_euler_angles", euler_angles);
+    pe_info(pe, "Euler angles alpha_z=%g, beta_x'=%g, gamma_z'=%g\n", euler_angles[0], euler_angles[1], euler_angles[2]);
     blue_phase_O8M_rot_init(cs, feparam, q, euler_angles);
   }
 
@@ -433,10 +431,8 @@ __host__ int blue_phase_rt_initial_conditions(pe_t * pe, rt_t * rt, cs_t * cs,
 
   if (strcmp(key1, "o2_rot") == 0) {
     pe_info(pe, "Initialising Q_ab using rotated O2 (BPII)\n");
-    if (strcmp(key1, "lc_q_euler_angles") == 0) {
-      rt_double_parameter_vector(rt, "lc_q_euler_angles", euler_angles);
-      pe_info(pe, "Euler angles alpha_z=%g, beta_x'=%g, gamma_z'=%g\n", euler_angles[0], euler_angles[1], euler_angles[2]);
-    }
+    rt_double_parameter_vector(rt, "lc_q_euler_angles", euler_angles);
+    pe_info(pe, "Euler angles alpha_z=%g, beta_x'=%g, gamma_z'=%g\n", euler_angles[0], euler_angles[1], euler_angles[2]);
     blue_phase_O2_rot_init(cs, feparam, q, euler_angles);
   }
 

--- a/tests/regression/d3q19/long64-chol-bp1rot.inp
+++ b/tests/regression/d3q19/long64-chol-bp1rot.inp
@@ -1,7 +1,7 @@
 ##############################################################################
 #
-#  BPII test
-#  Following initialisation of serial-init-bp2.inp
+#  BPI test.
+#  Following initialisation in serial-init-bp1.inp with different orientation
 #
 ##############################################################################
 
@@ -39,18 +39,19 @@ fd_gradient_calculation 3d_7pt_fluid
 #
 ###############################################################################
 
-lc_a0      0.0069
-lc_gamma   3.0
-lc_q0      0.1963495
-lc_kappa0  0.02
-lc_kappa1  0.02
+lc_a0         0.014384711
+lc_gamma      3.1764706
+lc_q0         0.27768018
+lc_kappa0     0.01
+lc_kappa1     0.01
 
 lc_xi      0.7
 lc_Gamma   0.1
 
-lc_q_initialisation o2
-lc_q_init_amplitude 0.3
-lc_init_redshift 0.91
+lc_q_initialisation o8m_rot
+lc_q_euler_angles 90_0_0
+lc_q_init_amplitude -0.2
+lc_init_redshift 0.83
 lc_anchoring_method none
 
 ###############################################################################

--- a/tests/regression/d3q19/long64-chol-bp1rot.log
+++ b/tests/regression/d3q19/long64-chol-bp1rot.log
@@ -1,0 +1,109 @@
+Welcome to Ludwig v0.14.0 (MPI version running on 8 processes)
+Start time: Wed Oct 27 16:36:54 2021
+
+Compiler:
+  name:           Gnu 11.2.0
+  version-string: 11.2.0
+
+Note assertions via standard C assert() are on.
+
+Target thread model: None.
+
+Read 24 user parameters from long64-chol-bp1rot.inp
+
+System details
+--------------
+System size:    32 32 32
+Decomposition:  2 2 2
+Local domain:   16 16 16
+Periodic:       1 1 1
+Halo nhalo:     2
+Reorder:        true
+Initialised:    1
+
+Free energy details
+-------------------
+
+Blue phase free energy selected.
+
+Liquid crystal blue phase free energy
+Bulk parameter A0:         =  1.4384711e-02
+Magnitude of order gamma   =  3.1764706e+00
+Pitch wavevector q0        =  2.7768018e-01
+... gives pitch length     =  2.2627417e+01
+Elastic constant kappa0    =  1.0000000e-02
+Elastic constant kappa1    =  1.0000000e-02
+Amplitude (uniaxial) order = -2.0000000e-01
+Effective aspect ratio xi  =  7.0000000e-01
+Chirality                  =  1.3500000e+00
+Reduced temperature        = -5.0000003e-01
+Initial redshift           =  8.3000000e-01
+Dynamic redshift update    =             no
+Liquid crystal activity                  No
+
+Using Beris-Edwards solver:
+Rotational diffusion const =  1.0000000e-01
+LC fluctuations:           =  off
+
+System properties
+----------------
+Mean fluid density:           1.00000e+00
+Shear viscosity               1.66667e+00
+Bulk viscosity                1.66667e+00
+Temperature                   0.00000e+00
+External body force density   0.00000e+00  0.00000e+00  0.00000e+00
+External E-field amplitude    0.00000e+00  0.00000e+00  0.00000e+00
+External E-field frequency    0.00000e+00
+External magnetic field       0.00000e+00  0.00000e+00  0.00000e+00
+
+Lattice Boltzmann distributions
+-------------------------------
+Model:            d3q19  
+SIMD vector len:  1
+Number of sets:   1
+Halo type:        full
+Input format:     binary
+Output format:    binary
+I/O grid:         1 1 1
+
+Lattice Boltzmann collision
+---------------------------
+Relaxation time scheme:   M10
+Hydrodynamic modes:       on
+Ghost modes:              on
+Isothermal fluctuations:  off
+Shear relaxation time:    5.50000e+00
+Bulk relaxation time:     5.50000e+00
+Ghost relaxation time:    1.00000e+00
+[User   ] Random number seed: 8361235
+
+Hydrodynamics
+-------------
+Hydrodynamics: on
+
+Order parameter I/O
+-------------------
+Order parameter I/O format:   
+I/O decomposition:            1 1 1
+
+Advection scheme order:  1 (default)
+Gradient calculation: 3d_7pt_fluid
+
+
+Initialising Q_ab using rotated O8M (BPI)
+Euler angles alpha_z=90, beta_x'=0, gamma_z'=0
+Initial conditions.
+
+Scalars - total mean variance min max
+[rho]       32768.00  1.00000000000  2.2204460e-16  1.00000000000  1.00000000000
+[phi]  4.1905445e-13  1.2788527e-17 6.0000000e-02 -4.4966058e-01 4.4966058e-01
+[phi] -1.3582468e-12 -4.1450404e-17 5.0000000e-02 -6.0000000e-01 6.0000000e-01
+[phi] -1.1957657e-12 -3.6491873e-17 5.0000000e-02 -6.0000000e-01 6.0000000e-01
+[phi]  3.9868186e-13  1.2166805e-17 6.0000000e-02 -4.4966058e-01 4.4966058e-01
+[phi] -1.7553736e-12 -5.3569752e-17 5.0000000e-02 -6.0000000e-01 6.0000000e-01
+
+Momentum - x y z
+[total   ]  0.0000000e+00  0.0000000e+00  0.0000000e+00
+[fluid   ]  0.0000000e+00  0.0000000e+00  0.0000000e+00
+
+Starting time step loop.

--- a/tests/regression/d3q19/long64-chol-bp2rot.inp
+++ b/tests/regression/d3q19/long64-chol-bp2rot.inp
@@ -1,7 +1,7 @@
 ##############################################################################
 #
 #  BPII test
-#  Following initialisation of serial-init-bp2.inp
+#  Following initialisation of serial-init-bp2.inp with different orientation
 #
 ##############################################################################
 
@@ -48,7 +48,8 @@ lc_kappa1  0.02
 lc_xi      0.7
 lc_Gamma   0.1
 
-lc_q_initialisation o2
+lc_q_initialisation o2_rot
+lc_q_euler_angles 45_45_0
 lc_q_init_amplitude 0.3
 lc_init_redshift 0.91
 lc_anchoring_method none

--- a/tests/regression/d3q19/long64-chol-bp2rot.log
+++ b/tests/regression/d3q19/long64-chol-bp2rot.log
@@ -1,0 +1,160 @@
+Welcome to Ludwig v0.14.0 (MPI version running on 8 processes)
+Start time: Wed Oct 27 16:43:26 2021
+
+Compiler:
+  name:           Gnu 11.2.0
+  version-string: 11.2.0
+
+Note assertions via standard C assert() are on.
+
+Target thread model: None.
+
+Read 24 user parameters from long64-chol-bp2rot.inp
+
+System details
+--------------
+System size:    32 32 32
+Decomposition:  2 2 2
+Local domain:   16 16 16
+Periodic:       1 1 1
+Halo nhalo:     2
+Reorder:        true
+Initialised:    1
+
+Free energy details
+-------------------
+
+Blue phase free energy selected.
+
+Liquid crystal blue phase free energy
+Bulk parameter A0:         =  6.9000000e-03
+Magnitude of order gamma   =  3.0000000e+00
+Pitch wavevector q0        =  1.9634950e-01
+... gives pitch length     =  3.2000007e+01
+Elastic constant kappa0    =  2.0000000e-02
+Elastic constant kappa1    =  2.0000000e-02
+Amplitude (uniaxial) order =  3.0000000e-01
+Effective aspect ratio xi  =  7.0000000e-01
+Chirality                  =  2.0057255e+00
+Reduced temperature        =  0.0000000e+00
+Initial redshift           =  9.1000000e-01
+Dynamic redshift update    =             no
+Liquid crystal activity                  No
+
+Using Beris-Edwards solver:
+Rotational diffusion const =  1.0000000e-01
+LC fluctuations:           =  off
+
+System properties
+----------------
+Mean fluid density:           1.00000e+00
+Shear viscosity               1.66667e+00
+Bulk viscosity                1.66667e+00
+Temperature                   0.00000e+00
+External body force density   0.00000e+00  0.00000e+00  0.00000e+00
+External E-field amplitude    0.00000e+00  0.00000e+00  0.00000e+00
+External E-field frequency    0.00000e+00
+External magnetic field       0.00000e+00  0.00000e+00  0.00000e+00
+
+Lattice Boltzmann distributions
+-------------------------------
+Model:            d3q19  
+SIMD vector len:  1
+Number of sets:   1
+Halo type:        full
+Input format:     binary
+Output format:    binary
+I/O grid:         1 1 1
+
+Lattice Boltzmann collision
+---------------------------
+Relaxation time scheme:   M10
+Hydrodynamic modes:       on
+Ghost modes:              on
+Isothermal fluctuations:  off
+Shear relaxation time:    5.50000e+00
+Bulk relaxation time:     5.50000e+00
+Ghost relaxation time:    1.00000e+00
+[User   ] Random number seed: 8361235
+
+Hydrodynamics
+-------------
+Hydrodynamics: on
+
+Order parameter I/O
+-------------------
+Order parameter I/O format:   
+I/O decomposition:            1 1 1
+
+Advection scheme order:  1 (default)
+Gradient calculation: 3d_7pt_fluid
+
+
+Initialising Q_ab using rotated O2 (BPII)
+Euler angles alpha_z=45, beta_x'=45, gamma_z'=0
+Initial conditions.
+
+Scalars - total mean variance min max
+[rho]       32768.00  1.00000000000  2.2204460e-16  1.00000000000  1.00000000000
+[phi] -1.0206918e-12 -3.1149042e-17 8.4935422e-02 -5.9727840e-01 5.9727840e-01
+[phi] -7.8728135e-12 -2.4025920e-16 4.5000000e-02 -3.0000000e-01 3.0000000e-01
+[phi] -1.4608759e-11 -4.4582393e-16 4.5000000e-02 -3.0000000e-01 3.0000000e-01
+[phi]  4.4785463e+02  1.3667439e-02 9.3490906e-02 -5.9885749e-01 6.0000000e-01
+[phi]  1.2765777e+02  3.8958061e-03 4.4853901e-02 -2.9998998e-01 2.9998998e-01
+
+Momentum - x y z
+[total   ]  0.0000000e+00  0.0000000e+00  0.0000000e+00
+[fluid   ]  0.0000000e+00  0.0000000e+00  0.0000000e+00
+
+Starting time step loop.
+
+Scalars - total mean variance min max
+[rho]       32768.00  1.00000000000  2.3534397e-10  0.99994882568  1.00004618664
+[phi] -6.1782286e+01 -1.8854457e-03 1.1641226e-02 -1.7865819e-01 3.3310126e-01
+[phi]  1.6566248e+02  5.0556177e-03 1.0451679e-02 -2.4498503e-01 2.5672772e-01
+[phi] -1.2027857e+01 -3.6706108e-04 1.0174710e-02 -2.4772676e-01 2.5529376e-01
+[phi]  3.9270784e+01  1.1984492e-03 1.1978320e-02 -1.7294678e-01 3.4809866e-01
+[phi]  2.5982022e+00  7.9290839e-05 1.0810133e-02 -2.5451840e-01 2.6076295e-01
+
+Free energies - timestep f v f/v f_bulk/v f_grad/v redshift
+[fe]          20000 -7.0999051989e-01  3.2768000000e+04 -2.1667191159e-05 -3.1595817022e-05  9.9286258634e-06  9.1000000000e-01
+
+Momentum - x y z
+[total   ]  4.6159604e-13  4.8495236e-13  7.4037998e-14
+[fluid   ]  4.6159604e-13  4.8495236e-13  7.4037998e-14
+
+Velocity - x y z
+[minimum ] -1.5631767e-05 -1.5180160e-05 -1.6060168e-05
+[maximum ]  1.2889113e-05  2.0437814e-05  1.3411893e-05
+
+Completed cycle 20000
+
+Timer resolution: 1e-06 second
+
+Timer statistics
+             Section:       tmin       tmax      total
+               Total:    602.078    602.078    602.078 602.078200 (1 call)
+      Time step loop:      0.023      0.121    602.025   0.030101 (20000 calls)
+         Propagation:      0.002      0.013     41.057   0.002053 (20000 calls)
+    Propagtn (krnl) :      0.002      0.013     40.951   0.002048 (20000 calls)
+           Collision:      0.004      0.020     95.821   0.004791 (20000 calls)
+   Collision (krnl) :      0.004      0.020     95.733   0.004787 (20000 calls)
+       Lattice halos:      0.001      0.032     32.279   0.001614 (20000 calls)
+       phi gradients:      0.003      0.024     85.017   0.004251 (20000 calls)
+    phi grad (krnl) :      0.003      0.017     69.708   0.003485 (20000 calls)
+           phi halos:      0.000      0.017     15.202   0.000760 (20000 calls)
+                 BBL:      0.000      0.000      0.016   0.000001 (20000 calls)
+   Force calculation:      0.007      0.037    170.190   0.008509 (20000 calls)
+   Phi force (krnl) :      0.003      0.027     70.392   0.003520 (20000 calls)
+          phi update:      0.006      0.067    171.798   0.008590 (20000 calls)
+      Velocity Halo :      0.000      0.045     15.034   0.000752 (20000 calls)
+BE mol field (krnl) :      0.002      0.014     42.845   0.002142 (20000 calls)
+BP BE update (krnl) :      0.003      0.016     66.731   0.003337 (20000 calls)
+     Advectn (krnl) :      0.001      0.016     32.028   0.001601 (20000 calls)
+ Advectn BCS (krnl) :      0.000      0.011     12.049   0.000602 (20000 calls)
+               Free1:      0.000      0.015      0.027   0.000001 (20000 calls)
+Warning: key/value present in input but not used:
+(Line 71): boundary_walls_on no
+
+End time: Wed Oct 27 16:53:28 2021
+Ludwig finished normally.


### PR DESCRIPTION
Hi Kevin,

This PR includes the new routines for rotated BP1 and BP2 configurations. The idea would be to replace the existing initialisations with these ones and pass euler_angles 0_0_0 for unrotated BPs.

This PR contains as well the newly defined routines for separate bulk and gradient contributions to the molecular field.

Cheers,
O