### PR TITLE
Added reference for CF1 initial configuration

### DIFF
--- a/src/blue_phase_init.c
+++ b/src/blue_phase_init.c
@@ -1417,6 +1417,8 @@ static int rotate_inplace(const rotation_t * rot, double r[3]) {
  *  Uses the current free energy parameters
  *     q0 (P=2pi/q0)
  *
+ *  See also P. Ribiere, S. Pirkl, P. Oswald, Phys. Rev. A 44, 8198--8209 (1991). 
+ *
  *****************************************************************************/
 
 int blue_phase_cf1_init(cs_t * cs, fe_lc_param_t * param, field_t * fq,
@@ -1521,6 +1523,8 @@ int blue_phase_cf1_init(cs_t * cs, fe_lc_param_t * param, field_t * fq,
  *
  *  Uses the current free energy parameters
  *     q0 (pitch = 2pi/q0)
+ *
+ *  See also P. Ribiere, S. Pirkl, P. Oswald, Phys. Rev. A 44, 8198--8209 (1991). 
  *
  *****************************************************************************/
 


### PR DESCRIPTION
Hi Kevin,

This is just an added reference for the CF1 (cholesteric finger of the first kind) initial configuration. It took me more than an hour to figure out what I did when I implemented this. Don't want to spend the time again.

Cheers,
O